### PR TITLE
Fix package naming typo

### DIFF
--- a/src/Strategy/Duck.java
+++ b/src/Strategy/Duck.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public abstract class Duck {
     FlyBehavior flyBehavior;

--- a/src/Strategy/FlyBehavior.java
+++ b/src/Strategy/FlyBehavior.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public interface FlyBehavior {
 

--- a/src/Strategy/FlyNoWay.java
+++ b/src/Strategy/FlyNoWay.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class FlyNoWay implements FlyBehavior {
 

--- a/src/Strategy/FlyRocketPowered.java
+++ b/src/Strategy/FlyRocketPowered.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class FlyRocketPowered implements FlyBehavior {
 

--- a/src/Strategy/FlyWithWings.java
+++ b/src/Strategy/FlyWithWings.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class FlyWithWings implements FlyBehavior {
 

--- a/src/Strategy/MainDuckSimulator.java
+++ b/src/Strategy/MainDuckSimulator.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class MainDuckSimulator {
     

--- a/src/Strategy/MallardDuck.java
+++ b/src/Strategy/MallardDuck.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class MallardDuck extends Duck {
 

--- a/src/Strategy/ModelDuck.java
+++ b/src/Strategy/ModelDuck.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class ModelDuck extends Duck {
 

--- a/src/Strategy/MuteQuack.java
+++ b/src/Strategy/MuteQuack.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class MuteQuack implements QuackBehavior {
 

--- a/src/Strategy/Quack.java
+++ b/src/Strategy/Quack.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class Quack implements QuackBehavior {
     

--- a/src/Strategy/QuackBehavior.java
+++ b/src/Strategy/QuackBehavior.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public interface QuackBehavior {
 

--- a/src/Strategy/Squeak.java
+++ b/src/Strategy/Squeak.java
@@ -1,4 +1,4 @@
-package Stretagy;
+package Strategy;
 
 public class Squeak implements QuackBehavior {
 


### PR DESCRIPTION
## Summary
- rename `src/Stretagy` folder to `src/Strategy`
- update package declarations from `Stretagy` to `Strategy`

## Testing
- `javac -d bin src/Strategy/*.java`
- `java -cp bin Strategy.MainDuckSimulator`


------
https://chatgpt.com/codex/tasks/task_e_685223815bf48328bc4c7bf766786aa3